### PR TITLE
No Renderizar el componente DogNotFound al inicio

### DIFF
--- a/src/components/DogNotFound/DogNotFound.jsx
+++ b/src/components/DogNotFound/DogNotFound.jsx
@@ -1,0 +1,11 @@
+import style from './DogNotFound.module.css'
+
+function DogNotFound () {
+  return (
+    <div className={style.DogNotFoundContainer}>
+      <h1>No se encontró ningún perro con estas características</h1>
+    </div>
+  )
+}
+
+export default DogNotFound

--- a/src/components/DogNotFound/DogNotFound.module.css
+++ b/src/components/DogNotFound/DogNotFound.module.css
@@ -1,0 +1,3 @@
+.DogNotFoundContainer {
+    color: black;
+}

--- a/src/components/DogsContainer/DogsContainer.jsx
+++ b/src/components/DogsContainer/DogsContainer.jsx
@@ -1,4 +1,5 @@
 import DogCard from '../DogCard/DogCard'
+import DogNotFound from '../DogNotFound/DogNotFound'
 
 import style from './DogsContainer.module.css'
 
@@ -6,14 +7,16 @@ function DogsContainer ({ dogs }) {
   return (
     <div className={style.DogsContainer}>
       {
-                dogs.list.filter(dog => dog.image).map((dog, index) => <DogCard
-                  name={dog.name}
-                  image={dog.image}
-                  temperament={dog.temperament}
-                  weight={dog.weight}
-                  id={dog.id}
-                  key={dog.id}
-                                                                       />)
+                dogs && dogs.list.length
+                  ? dogs.list.filter(dog => dog.image).map((dog, index) => <DogCard
+                      name={dog.name}
+                      image={dog.image}
+                      temperament={dog.temperament}
+                      weight={dog.weight}
+                      id={dog.id}
+                      key={dog.id}
+                                                                           />)
+                  : <DogNotFound />
             }
     </div>
   )

--- a/src/components/DogsContainer/DogsContainer.jsx
+++ b/src/components/DogsContainer/DogsContainer.jsx
@@ -1,9 +1,26 @@
+import { useState, useEffect, useRef } from 'react'
+
 import DogCard from '../DogCard/DogCard'
 import DogNotFound from '../DogNotFound/DogNotFound'
 
 import style from './DogsContainer.module.css'
 
 function DogsContainer ({ dogs }) {
+  const [showNotFound, setShowNotFound] = useState(false)
+
+  const firstTime = useRef(true)
+
+  useEffect(() => {
+    if (firstTime && dogs.list.length) {
+      handleNotFound()
+    }
+  }, [dogs.list])
+
+  function handleNotFound () {
+    setShowNotFound(true)
+    firstTime.current = false
+  }
+
   return (
     <div className={style.DogsContainer}>
       {
@@ -16,7 +33,7 @@ function DogsContainer ({ dogs }) {
                       id={dog.id}
                       key={dog.id}
                                                                            />)
-                  : <DogNotFound />
+                  : showNotFound ? <DogNotFound /> : null
             }
     </div>
   )

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -99,9 +99,7 @@ function Home () {
                     </div>)
                   : null
             }
-        {
-                showDogs.list.length ? <DogsContainer dogs={showDogs} /> : null
-            }
+        <DogsContainer dogs={showDogs} />
         {
                 globalState.dogs.length > 8
                   ? (


### PR DESCRIPTION
Se modificó el componente DogsContainer para que no renderizara el componente DogNotFound sino hasta después de que se hayan cargado todas las cartas de perros al menos una vez. Luego de ello, se puede renderizar dicho componente.